### PR TITLE
secret_pred called before defined bug fix

### DIFF
--- a/python/trustmark/trustmark.py
+++ b/python/trustmark/trustmark.py
@@ -192,8 +192,8 @@ class TrustMark():
             else:
                 return secret_pred, detected, version
         else:
-            assert len(secret_pred.shape)==2
-            secret_pred = ''.join(str(int(x)) for x in secret_pred[0])
+            assert len(secret_binaryarray.shape)==2
+            secret_pred = ''.join(str(int(x)) for x in secret_binaryarray[0])
             return secret_pred, True, -1
          
     def encode(self, cover_image, string_secret, MODE='text', WM_STRENGTH=0.95, WM_MERGE='bilinear'):


### PR DESCRIPTION

## Motivation and Context

Bug fix. When `use_ECC` is `False`, the `decode` method of the `Trustmark` class was trying to process `secret_pred` which is not defined in this case. `secret_pred` is only defined when using the ECC decoding which is bypassed when `use_ECC=False`. I assume the intension is to process `secret_binaryarray` directly and have amended respectively.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
