### PR TITLE
feat: support user-specified JPEG output quality

### DIFF
--- a/rust/crates/trustmark-cli/README.md
+++ b/rust/crates/trustmark-cli/README.md
@@ -53,6 +53,7 @@ Options:
 | `-w, --watermark <WATERMARK>` | The watermark (payload) to encode.  | Any a binary string such as  `0101010101`. Only 0 and 1 characters are allowed. Maximum length is governed by the version selected.  Default is a random binary string. |
 | `--version <VERSION>`  |  The BCH version to encode with. | One of `BCH_SUPER` (default), `BCH_5`, `BCH_4`, or `BCH_3`. |
 | `--variant <VARIANT>`  | The model variant to encode with. | `Q` (default), `B`, `C`, and `P`. |
+| `--quality <QUALITY>`  | If the requested output format is JPEG, the output quality to encode. | A number between 0 and 100. The default is 90. |
 | `-h, --help` | Display help information. | N/A |
 
 ### Decoding watermarks

--- a/rust/crates/trustmark-cli/src/main.rs
+++ b/rust/crates/trustmark-cli/src/main.rs
@@ -39,6 +39,9 @@ enum Command {
         /// The model variant to encode with.
         #[arg(long)]
         variant: Option<Variant>,
+        /// If the requested output is JPEG, the quality to use for encoding.
+        #[arg(long)]
+        quality: Option<u8>,
     },
     /// Decode a watermark from an image
     Decode {
@@ -109,6 +112,7 @@ fn main() {
             output,
             watermark,
             version,
+            quality,
             ..
         } => {
             let input = image::open(input).unwrap();
@@ -120,15 +124,16 @@ fn main() {
             let format = ImageFormat::from_path(&output).unwrap();
             match format {
                 // JPEG encoding can make visual artifacts worse, so we encode with a higher
-                // quality than the default.
+                // quality than the default (or the quality requested by the user).
                 ImageFormat::Jpeg => {
+                    let quality = quality.unwrap_or(90);
                     let mut writer = OpenOptions::new()
                         .write(true)
                         .create(true)
                         .truncate(true)
                         .open(&output)
                         .unwrap();
-                    let encoder = JpegEncoder::new_with_quality(&mut writer, 99);
+                    let encoder = JpegEncoder::new_with_quality(&mut writer, quality);
                     encoded.to_rgba8().write_with_encoder(encoder).unwrap();
                 }
                 _ => {


### PR DESCRIPTION
## Description

This commit changes the default JPEG output quality to 90 and adds support for a `--quality` CLI flag that allows the user to change the output quality.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
