### PR TITLE
Fix spelling mistake.

### DIFF
--- a/c2pa/README.md
+++ b/c2pa/README.md
@@ -12,6 +12,6 @@ For more information, see the [FAQ](../FAQ.md#how-does-trustmark-align-with-prov
 
 ## Signpost watermark
 
-TrustMark [coexists well with most other image watermarks](https://arxiv.org/abs/2501.17356) and so can be used as a _signpost_ to indicate the co-presence of another watermarking technology.  This can be helpful, sinace as an open technology, TrustMark can be used to indicate (signpost) which decoder to obtain and run on an image to decode a soft binding identifier for C2PA.
+TrustMark [coexists well with most other image watermarks](https://arxiv.org/abs/2501.17356) and so can be used as a _signpost_ to indicate the co-presence of another watermarking technology.  This can be helpful, since as an open technology, TrustMark can be used to indicate (signpost) which decoder to obtain and run on an image to decode a soft binding identifier for C2PA.
 
 In this mode the encoding should be `Encoding.BCH_SUPER` and the payload contain an integer identifier that describes the co-present watermark.  The integer should be taken from the registry of C2PA-approved watermarks listed in this normative C2PA [softbinding-algorithms-list](https://github.com/c2pa-org/softbinding-algorithms-list) repository.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
**Fix typo in comment: "sinace" → "since"**

## Description

Corrected a spelling error in a comment/documentation where "sinace" was used instead of "since", improving clarity for readers.

## Related Issue

N/A – Minor documentation/comment fix not tied to an open issue.

## Motivation and Context

Spelling mistakes reduce clarity and professionalism. This fix improves readability without affecting functionality.

## How Has This Been Tested?

No testing needed. This is a comment-only change and does not impact runtime behavior.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
