### PR TITLE
fix: doc build

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1736,13 +1736,14 @@ dependencies = [
 
 [[package]]
 name = "trustmark"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "criterion",
  "fast_image_resize",
  "image",
  "ndarray",
  "ort",
+ "ort-sys",
  "thiserror",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trustmark"
 description = "A Rust implementation of TrustMark"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   "John Collomosse <collomos@adobe.com>",
   "Maurice Fisher <mfisher@adobe.com>",
@@ -30,6 +30,7 @@ image = "0.25.6"
 fast_image_resize = { version = "5.1.4", features = ["image", "rayon"] }
 ndarray = "0.16"
 ort = "=2.0.0-rc.8"
+ort-sys = { version = "=2.0.0-rc.8", default-features = false }
 thiserror = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
Pins the version of `ort-sys` to match the (rc) version of `ort` as suggested in [this issue][0].

[0]: https://github.com/pykeio/ort/issues/399
