### PR TITLE
fix: integer truncation bug

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "trustmark"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "criterion",
  "fast_image_resize",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trustmark"
 description = "A Rust implementation of TrustMark"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   "John Collomosse <collomos@adobe.com>",
   "Maurice Fisher <mfisher@adobe.com>",

--- a/rust/src/image_processing.rs
+++ b/rust/src/image_processing.rs
@@ -234,12 +234,13 @@ pub(super) fn remove_boundary_artifact(
 
     // We want one dimension of the output to be 256 and we we want the aspect ratio of the output
     // to match the input image.
+    let other_dim;
     let mut mean_padded: ndarray::Array4<f32> = if width > height {
-        let other = ((width as f32 / height as f32) * 256.0) as usize;
-        ndarray::Array4::zeros([1, 3, 256_usize, other])
+        other_dim = ((width as f32 / height as f32) * 256.0) as usize;
+        ndarray::Array4::zeros([1, 3, 256_usize, other_dim])
     } else {
-        let other = (height / width) * 256;
-        ndarray::Array4::zeros([1, 3, other, 256])
+        other_dim = ((height as f32 / width as f32) * 256.0) as usize;
+        ndarray::Array4::zeros([1, 3, other_dim, 256])
     };
 
     // This softens the transition between the residual area and the rest of the image.
@@ -253,14 +254,12 @@ pub(super) fn remove_boundary_artifact(
     }
 
     if width > height {
-        let other = ((width as f32 / height as f32) * 256.0) as usize;
-        let leftover = (other - 256) / 2;
+        let leftover = (other_dim - 256) / 2;
         mean_padded
             .slice_mut(s![.., .., .., leftover..(leftover + 256)])
             .assign(&residual);
     } else {
-        let other = ((height as f32 / width as f32) * 256.0) as usize;
-        let leftover = (other - 256) / 2;
+        let leftover = (other_dim - 256) / 2;
         mean_padded
             .slice_mut(s![.., .., leftover..(leftover + 256), ..])
             .assign(&residual);
@@ -271,6 +270,8 @@ pub(super) fn remove_boundary_artifact(
 
 #[cfg(test)]
 mod tests {
+    use ndarray::Array4;
+
     use super::*;
 
     #[test]
@@ -321,5 +322,16 @@ mod tests {
             center_crop_size_and_offset(Variant::P, &image),
             (100, 100, 0, 5)
         );
+    }
+
+    #[test]
+    fn remove_boundary_artifact_tall() {
+        let residual: Array4<f32> = Array4::ones([1, 3, 256, 256]);
+        let width = 256;
+        let height = 298;
+
+        let output = remove_boundary_artifact(residual.into_dyn(), (width, height), Variant::P);
+
+        assert_eq!(output.shape(), &[1, 3, 298, 256]);
     }
 }


### PR DESCRIPTION
## Description

This commit fixes a bug where the padded output array would have incorrect dimensions due to doing the dimensional math on integers instead of floats like the other branch.

This also refactors a bit to make this mistake harder to make and adds a test that would have caught this bug.

## How Has This Been Tested?

Added a new unit test.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
